### PR TITLE
fix: silence ascii deprecation

### DIFF
--- a/vendor/voku/portable-ascii/src/voku/helper/ASCII.php
+++ b/vendor/voku/portable-ascii/src/voku/helper/ASCII.php
@@ -798,7 +798,7 @@ final class ASCII
         bool $remove_unsupported_chars = true,
         bool $replace_extra_symbols = false,
         bool $use_transliterate = false,
-        bool $replace_single_chars_only = null
+        ?bool $replace_single_chars_only = null
     ): string {
         if ($str === '') {
             return '';


### PR DESCRIPTION
## Summary
- fix deprecation warning by adding explicit nullable type to `ASCII::to_ascii`

## Testing
- `php artisan`
- `php artisan test` *(fails: Test directory "tests/Unit" not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a6a654cdf8832dbaba626ea9279d7c